### PR TITLE
ready 상태의 Tag 객체 구현 마무리

### DIFF
--- a/css/boardStyle.css
+++ b/css/boardStyle.css
@@ -174,6 +174,7 @@ main {
 .board {
     flex: 1;
     position: relative;
+    overflow: auto;
     height: 860px;
     box-sizing: border-box;
 }

--- a/css/boardStyle.css
+++ b/css/boardStyle.css
@@ -172,9 +172,6 @@ main {
 }
 
 .board {
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
     flex: 1;
     position: relative;
     height: 860px;

--- a/js/board.js
+++ b/js/board.js
@@ -21,15 +21,14 @@ const board = {
   },
 
   // 너비 우선 탐색으로 body에서부터 children을 통해 Tag 객체를 찾아서 반환
-  // DOM요소만 가지고 그 DOM 요소에 해당하는 Tag 객체를 찾을 때 사용
-  searchElem(target, start = this.body) {
+  getTag(condition, start = this.body) {
     const visited = new Map();
     const queue = [start];
     let tag;
 
     while (queue.length) {
       tag = queue.shift();
-      if (tag.elem === target) return tag;
+      if (condition(tag)) return tag;
       if (!visited.has(tag)) {
         visited.set(tag, null);
         queue.push(...tag.children);
@@ -38,20 +37,17 @@ const board = {
     return null;
   },
 
-  searchByLocation(event, start = this.body) {
-    const visited = new Map();
-    const queue = [start];
-    let tag;
+  // event.target으로 그 DOM 요소에 해당하는 Tag 객체 반환
+  searchByElem(event, start = this.body) {
+    const { target } = event;
+    const condition = (tag) => tag.elem === target;
+    return this.getTag(condition, start);
+  },
 
-    while (queue.length) {
-      tag = queue.shift();
-      if (this.isInside(tag, this.getOffset(event))) return tag;
-      if (!visited.has(tag)) {
-        visited.set(tag, null);
-        queue.push(...tag.children);
-      }
-    }
-    return null;
+  // 현재 마우스가 어떤 태그 DOM 요소 위에 있는지 찾아서 해당하는 Tag 객체 반환
+  searchByLocation(event, start = this.body) {
+    const condition = (tag) => this.isInside(tag, this.getOffset(event));
+    return this.getTag(condition, start);
   },
 
   // 현재 시점에서의 보드 DOM 요소의 width, height를 반환
@@ -110,8 +106,7 @@ const clickHandler = (event) => {
     ready.setPos(x, y, grid);
     ready.setState("located");
   } else {
-    const { target } = event;
-    board.selected = board.searchElem(target);
+    board.selected = board.searchByElem(event);
     board.selected.setState("selected");
   }
 };

--- a/js/board.js
+++ b/js/board.js
@@ -36,6 +36,12 @@ const board = {
     return tag;
   },
 
+  // 현재 시점에서의 보드 DOM 요소의 width, height를 반환
+  getSize() {
+    const { width, height } = this.elem.getBoundingClientRect();
+    return [ width, height ];
+  },
+
   // 보드의 좌상단을 x = 0, y = 0으로 하고 스크롤까지 고려한 현재 마우스 좌표 반환
   getOffset(event) {
     const { clientX, clientY } = event;

--- a/js/board.js
+++ b/js/board.js
@@ -1,6 +1,6 @@
 const board = {
   elem: document.querySelector(".board"),
-  body: new Tag({ tagName: "body", keyword: [], attr: [] }),
+  body: new Tag({ tagName: "body", keyword: [], attr: [] }, { state: "located" }),
   ready: null, // 태그 선택 창에서 선택한 요소
   selected: null,
   grid,
@@ -29,13 +29,29 @@ const board = {
 
     while (queue.length) {
       tag = queue.shift();
-      if (tag.elem === target) break;
+      if (tag.elem === target) return tag;
       if (!visited.has(tag)) {
         visited.set(tag, null);
         queue.push(...tag.children);
       }
     }
-    return tag;
+    return null;
+  },
+
+  searchByLocation(event, start = this.body) {
+    const visited = new Map();
+    const queue = [start];
+    let tag;
+
+    while (queue.length) {
+      tag = queue.shift();
+      if (this.isInside(tag, this.getOffset(event))) return tag;
+      if (!visited.has(tag)) {
+        visited.set(tag, null);
+        queue.push(...tag.children);
+      }
+    }
+    return null;
   },
 
   // 현재 시점에서의 보드 DOM 요소의 width, height를 반환
@@ -52,18 +68,19 @@ const board = {
     return [ clientX - x + scrollLeft, clientY - y + scrollTop ];
   },
 
+  isInside(tag, offset) {
+    const { width, height, x, y } = tag;
+    const [ cx, cy ] = offset;
+    return x <= cx && cx <= x + width && y <= cy && cy <= y + height;
+  },
+
   // tagData의 태그 data를 인자로 받아서 Tag 객체를 생성하고,
   // board의 ready에 할당함
   add(data) {
-    const { keyword } = data;
     const tag = new Tag(data, {});
     const { size } = grid;
     if (this.ready) this.delete(this.ready);
-    if (keyword.includes("block")) {
-      tag.setSize(this.body.width - size * 2 + 1, size * 3 + 1);
-    } else {
-      tag.setSize(size * 6 + 1, size * 3 + 1);
-    }
+    tag.setSize(size * 6 + 1, size * 3 + 1);
     tag.setPos(0, 0, grid);
     tag.setState("ready");
     board.elem.appendChild(tag.elem);
@@ -110,10 +127,19 @@ const mouseoverHandler = (event) => {
 
 // 마우스가 보드 안에서 움직일 때 이벤트 핸들러
 const mousemoveHandler = (event) => {
-  const { ready } = board;
+  const { ready, body } = board;
+  const { size } = grid;
   if (!ready) return;
-  const [ x, y ] = board.getOffset(event);
-  ready.setPos(x, y, grid);
+  const parent = board.searchByLocation(event);
+  if (parent === body && ready.keyword.includes("block")) {
+    const [ _, y ] = board.getOffset(event);
+    ready.setSize(body.width - size * 2 + 1, size * 3 + 1);
+    ready.setPos(body.x + size, y, grid);
+  } else {
+    const [ x, y ] = board.getOffset(event);
+    ready.setSize(size * 6 + 1, size * 3 + 1);
+    ready.setPos(x, y, grid);
+  }
 };
 
 // 마우스가 보드 안에서 바깥으로 나갈 때 이벤트 핸들러

--- a/js/board.js
+++ b/js/board.js
@@ -14,10 +14,18 @@ const board = {
     this.grid.init(this);
     const { size } = this.grid;
     [ width, height ] = [ trim(width, size), trim(height, size) ];
-    const [ boardWidth, boardHeight ] = this.getSize();
     this.body.setSize(width, height);
-    this.body.setPos((boardWidth - width) / 2, (boardHeight - height) / 2, this.grid);
     this.body.show();
+    this.grid.paintGrid();
+    this.body.setPos((this.width - width) / 2, (this.height - height) / 2, this.grid);
+  },
+
+  // 현재 시점에서의 보드 DOM 요소의 width, height를 반환
+  get width() {
+    return this.elem.scrollWidth;
+  },
+  get height() {
+    return this.elem.scrollHeight;
   },
 
   // 너비 우선 탐색으로 body에서부터 children을 통해 Tag 객체를 찾아서 반환
@@ -48,12 +56,6 @@ const board = {
   searchByLocation(event, start = this.body) {
     const condition = (tag) => this.isInside(tag, this.getOffset(event));
     return this.getTag(condition, start);
-  },
-
-  // 현재 시점에서의 보드 DOM 요소의 width, height를 반환
-  getSize() {
-    const { width, height } = this.elem.getBoundingClientRect();
-    return [ width, height ];
   },
 
   // 보드의 좌상단을 x = 0, y = 0으로 하고 스크롤까지 고려한 현재 마우스 좌표 반환
@@ -97,17 +99,14 @@ const board = {
 // board의 ready값이 존재 -> 태그 선택 바에서 태그를 선택한 상태
 // 그렇지 않은 경우 -> 보드에 표시된 태그를 선택한 상태
 const clickHandler = (event) => {
-  const { target, currentTarget } = event;
-  if (target === currentTarget) return;
-
   const { ready } = board;
   if (ready) {
     const [ x, y ] = board.getOffset(event);
     ready.setPos(x, y, grid);
     ready.setState("located");
   } else {
-    board.selected = board.searchByElem(event);
-    board.selected.setState("selected");
+    board.selected = board.searchByLocation(event);
+    board.selected?.setState("selected");
   }
 };
 
@@ -150,4 +149,4 @@ board.elem.addEventListener("mouseover", mouseoverHandler);
 board.elem.addEventListener("mousemove", mousemoveHandler);
 board.elem.addEventListener("mouseout", mouseoutHandler);
 
-board.init(1296, 800);
+board.init(1200, 800);

--- a/js/board.js
+++ b/js/board.js
@@ -92,6 +92,12 @@ const board = {
     const { children } = parent ?? {};
     board.elem.removeChild(elem);
     if (children) children.splice(children.indexOf(tag), 1);
+  },
+
+  clearReady() {
+    if (!this.ready) return;
+    this.delete(this.ready);
+    this.ready = null;
   }
 };
 
@@ -144,9 +150,27 @@ const mouseoutHandler = () => {
   ready.setState("none");
 };
 
+const mousedownHandler = (event) => {
+  const { which, button } = event;
+  if (which === 3 || button === 2) {
+    board.clearReady();
+  }
+};
+
 board.elem.addEventListener("click", clickHandler);
 board.elem.addEventListener("mouseover", mouseoverHandler);
 board.elem.addEventListener("mousemove", mousemoveHandler);
 board.elem.addEventListener("mouseout", mouseoutHandler);
+board.elem.addEventListener("mousedown", mousedownHandler);
+board.elem.addEventListener("contextmenu", (event) => event.preventDefault());
+
+const keydownHandler = ({ key }) => {
+  switch (key) {
+    case "Escape":
+      board.clearReady();
+  }
+};
+
+document.addEventListener("keydown", keydownHandler);
 
 board.init(1200, 800);

--- a/js/board.js
+++ b/js/board.js
@@ -13,8 +13,10 @@ const board = {
     this.elem.appendChild(this.body.elem);
     this.grid.init(this);
     const { size } = this.grid;
-    this.body.setSize(trim(width, size), trim(height, size));
-    this.body.setPos(0, 0, this.grid);
+    [ width, height ] = [ trim(width, size), trim(height, size) ];
+    const [ boardWidth, boardHeight ] = this.getSize();
+    this.body.setSize(width, height);
+    this.body.setPos((boardWidth - width) / 2, (boardHeight - height) / 2, this.grid);
     this.body.show();
   },
 

--- a/js/grid.js
+++ b/js/grid.js
@@ -11,19 +11,13 @@ const grid = {
   // 2. 격자를 그리고 격자를 담고 있는 DOM 요소를 보드 DOM 요소에 추가하여 화면에 표시
   init(board) {
     this.board = board;
-    const [ width, height ] = this.getBoardSize();
+    const [ width, height ] = board.getSize();
 
     this.elem = document.createElement('div');
     this.elem.classList.add('board-grid');
     setElemSize(this.elem, width, height);
     setElemPos(this.elem, 0, 0);
     this.paintGrid();
-  },
-
-  // 현재 시점에서의 보드 DOM 요소의 width, height를 반환
-  getBoardSize() {
-    const { x, y, right, bottom } = this.board.elem.getBoundingClientRect();
-    return [ right - x, bottom - y ];
   },
 
   // 격자 선 그리기
@@ -48,7 +42,7 @@ const grid = {
   // 2. size와 margin을 기준으로 일정 간격으로 가로 세로 선 생성
   // 3. 격자를 담고 있는 DOM 요소를 보드 DOM 요소에 추가하여 화면에 표시
   paintGrid() {
-    const [ width, height ] = this.getBoardSize();
+    const [ width, height ] = this.board.getSize();
     this.margin = (width % this.size) / 2;
 
     this.cols = [...Array(parseInt(width / this.size) + 1)]

--- a/js/grid.js
+++ b/js/grid.js
@@ -7,17 +7,12 @@ const grid = {
   // 그래서 board.init()할 때 grid.init()도 같이 해 주고,
   // board를 전역 변수로 참조하는게 아니라 이 시점에서 grid.board에 board를 할당한다.
 
-  // 1. 격자를 표현하는 선들을 담을 DOM 요소 생성한다.
-  // 2. 격자를 그리고 격자를 담고 있는 DOM 요소를 보드 DOM 요소에 추가하여 화면에 표시
+  // 격자를 표현하는 선들을 담을 DOM 요소 생성한다.
   init(board) {
     this.board = board;
-    const [ width, height ] = board.getSize();
-
     this.elem = document.createElement('div');
     this.elem.classList.add('board-grid');
-    setElemSize(this.elem, width, height);
     setElemPos(this.elem, 0, 0);
-    this.paintGrid();
   },
 
   // 격자 선 그리기
@@ -27,11 +22,11 @@ const grid = {
     
     if (isColumn) {
       line.classList.add('line-column');
-      setElemSize(line, 1, "100%");
+      setElemSize(line, 1, this.board.height);
       setElemPos(line, index * this.size + this.margin, 0);
     } else {
       line.classList.add('line-row');
-      setElemSize(line, "100%", 1);
+      setElemSize(line, this.board.width, 1);
       setElemPos(line, 0, index * this.size + this.margin);
     }
     return line;
@@ -42,7 +37,7 @@ const grid = {
   // 2. size와 margin을 기준으로 일정 간격으로 가로 세로 선 생성
   // 3. 격자를 담고 있는 DOM 요소를 보드 DOM 요소에 추가하여 화면에 표시
   paintGrid() {
-    const [ width, height ] = this.board.getSize();
+    const { width, height } = this.board;
     this.margin = (width % this.size) / 2;
 
     this.cols = [...Array(parseInt(width / this.size) + 1)]
@@ -52,6 +47,7 @@ const grid = {
       .map((_, i) => this.getLine(i))
       .forEach(line => this.elem.appendChild(line));
 
+    setElemSize(this.elem, width, height);
     this.board.elem.appendChild(this.elem);
   },
 

--- a/js/grid.js
+++ b/js/grid.js
@@ -23,11 +23,11 @@ const grid = {
     if (isColumn) {
       line.classList.add('line-column');
       setElemSize(line, 1, this.board.height);
-      setElemPos(line, index * this.size + this.margin, 0);
+      setElemPos(line, index * this.size + this.marginX, 0);
     } else {
       line.classList.add('line-row');
       setElemSize(line, this.board.width, 1);
-      setElemPos(line, 0, index * this.size + this.margin);
+      setElemPos(line, 0, index * this.size + this.marginY);
     }
     return line;
   },
@@ -38,12 +38,15 @@ const grid = {
   // 3. 격자를 담고 있는 DOM 요소를 보드 DOM 요소에 추가하여 화면에 표시
   paintGrid() {
     const { width, height } = this.board;
-    this.margin = (width % this.size) / 2;
+    this.marginX = (width % this.size) / 2;
+    this.marginY = (height % this.size) / 2;
+    this.colCount = parseInt(width / this.size) + 1;
+    this.rowCount = parseInt(height / this.size) + 1;
 
-    this.cols = [...Array(parseInt(width / this.size) + 1)]
+    this.cols = [...Array(this.colCount)]
       .map((_, i) => this.getLine(i, true))
       .forEach(line => this.elem.appendChild(line));
-    this.rows = [...Array(parseInt(height / this.size) + 1)]
+    this.rows = [...Array(this.rowCount)]
       .map((_, i) => this.getLine(i))
       .forEach(line => this.elem.appendChild(line));
 

--- a/js/tag.js
+++ b/js/tag.js
@@ -35,13 +35,20 @@ class Tag {
   // DOM 요소의 위치 설정 (transform 스타일 설정)
   setPos(x, y, grid) {
     if (grid) {
-      const { size, margin } = grid;
-      this.x = (trim(x, size) + margin) ?? this.x;
-      this.y = (trim(y, size) + margin) ?? this.x;
+      const { size, marginX, marginY, colCount, rowCount } = grid;
+      this.x = (trim(x, size) + marginX) ?? this.x;
+      this.y = (trim(y, size) + marginY) ?? this.x;
+      if (this.x + this.width > colCount * size + marginX) {
+        this.x = (colCount - parseInt(this.width / size) - 1) * size + marginX;
+      }
+      if (this.y + this.height > rowCount * size + marginY) {
+        this.y = (rowCount - parseInt(this.height / size) - 1) * size + marginY;
+      }
     } else {
       this.x = x ?? this.x;
       this.y = y ?? this.y;
     }
+
     this.elem.style.transform = `translate(${this.x}px, ${this.y}px)`;
   }
 


### PR DESCRIPTION
Closed #33 

1. 잔상이 화면 밖으로 빠져나가서 스크롤바가 생기는 현상 수정
2. 현재 마우스가 위치한 곳의 태그를 인식하도록 함
  + body 태그 안쪽에서만 블록 태그의 width가 늘어나도록 함
3. ready 상태의 태그를 취소할 수 있도록 함
4. body 태그 가운데 정렬 시킴
5. 보드가 뷰포트를 넘어가면 스크롤바가 생기도록 함