### PR TITLE
보드 UI 개선

### DIFF
--- a/css/boardStyle.css
+++ b/css/boardStyle.css
@@ -538,6 +538,12 @@ main {
     color: white;
 }
 
+.tag-text-loc {
+    justify-content: normal;
+    align-items: normal;
+    padding-left: 3px;
+}
+
 .board-grid {
     position: absolute;
     z-index: 9;

--- a/js/attrBtn.js
+++ b/js/attrBtn.js
@@ -2,15 +2,25 @@ const btnAttrAdd = document.querySelector(".btn-attr-add");
 const sectionAttrAdd = document.querySelector(".sect-attr-add");
 const btnAttrDelete = document.querySelector(".btn-attr-delete.input-delete");
 const showAttrMenu = document.querySelector(".wrap-attr-menu");
+const btnTagDelete = document.querySelector(".btn-trash");
 
-function addOn() {
-    sectionAttrAdd.classList.add("on");
-    showAttrMenu.classList.add("on");
-}
-function deleteOn() {
-    sectionAttrAdd.classList.remove("on");
-    showAttrMenu.classList.remove("on");
-}
+const addOn = () => {
+  sectionAttrAdd.classList.add("on");
+  showAttrMenu.classList.add("on");
+};
+
+const deleteOn = () => {
+  sectionAttrAdd.classList.remove("on");
+  showAttrMenu.classList.remove("on");
+};
+
+const deleteTag = () => {
+  const { selected } = board;
+  if (!selected) return;
+  board.clearSelected();
+  board.delete(selected);
+};
 
 btnAttrAdd.addEventListener("click", addOn);
 btnAttrDelete.addEventListener("click", deleteOn);
+btnTagDelete.addEventListener("click", deleteTag);

--- a/js/board.js
+++ b/js/board.js
@@ -178,12 +178,16 @@ const board = {
     });
   },
 
+  clearSelected() {
+    this.selected?.setState("located");
+    this.selected?.elem?.classList?.remove('selected-tag');
+    this.selected = null;
+  },
+
   select(event) {
     const nextSelected = this.searchByLocation(event);
     if (nextSelected === this.selected || !nextSelected) {
-      this.selected?.setState("located");
-      this.selected?.elem?.classList?.remove('selected-tag');
-      this.selected = null;
+      this.clearSelected();
       this.showTagBar();
     } else if (this.selected) {
       this.selected.setState("located");

--- a/js/board.js
+++ b/js/board.js
@@ -174,6 +174,7 @@ const board = {
     this.forEach(tag => {
       if (tag.state === "modified") {
         tag.setState("located");
+        tag.rearrangeChildren();
       }
     });
   },
@@ -231,11 +232,13 @@ const board = {
             tag.setState("located");
             tag.restoreSize();
             tag.restorePos();
+            tag.rearrangeChildren();
           } else {
             const tagArr = this.searchAllTagsByLocation(event);
             if (tagArr) {
               if (!tagArr.includes(tag)) {
                 tag.restoreSize();
+                tag.rearrangeChildren();
               }
             }
           }
@@ -247,6 +250,7 @@ const board = {
           tag.setState("located");
           tag.restoreSize();
           tag.restorePos();
+          tag.rearrangeChildren();
         }
       });
     }

--- a/js/board.js
+++ b/js/board.js
@@ -144,8 +144,10 @@ const board = {
   // Tag 객체에 해당되는 DOM 요소 삭제
   // Tag 객체의 부모가 children 배열에서 참조하고 있는 값을 삭제하여 메모리에서 제거
   delete(tag) {
-    const { elem } = tag;
-    this.elem.removeChild(elem);
+    if (tag.tagName === "body") return;
+    this.forEach((curTag) => {
+      this.elem.removeChild(curTag.elem);
+    }, tag);
     this.deleteFromTree(tag);
   },
 
@@ -422,9 +424,15 @@ const mouseoutHandler = () => {
 // 마우스 우클릭 이벤트 핸들러
 const mousedownHandler = (event) => {
   const { which, button } = event;
-  const { selected } = board;
+  const { ready, selected } = board;
   if (which === 3 || button === 2) {
-    board.clearReady();
+    const curTag = board.searchByLocation(event);
+    if (ready) {
+      board.clearReady();
+    } else if (selected && curTag === selected) {
+      board.clearSelected();
+      board.delete(selected);
+    }
   } else {
     if (selected) {
       board.dragStart(event);
@@ -452,6 +460,12 @@ const keydownHandler = ({ key }) => {
   switch (key) {
     case "Escape":
       board.clearReady();
+      break;
+    case "Delete":
+      const { selected } = board;
+      if (!selected) return;
+      board.clearSelected();
+      board.delete(selected);
   }
 };
 

--- a/js/board.js
+++ b/js/board.js
@@ -150,8 +150,8 @@ const board = {
   },
 
   deleteFromTree(tag) {
-    const { children } = tag.parent ?? {};
-    if (children) children.splice(children.indexOf(tag), 1);
+    const { parent } = tag;
+    if (parent) parent.remove(tag);
   },
 
   // ready 상태의 Tag 객체를 located 상태로 변경
@@ -159,16 +159,14 @@ const board = {
     tag.setState("located");
     if (type === "ready") {
       const parent = this.searchByLocation(event);
-      parent.children.push(tag);
-      tag.parent = parent;
+      parent.push(tag);
       this.clearReady(false, false);
     }
     // 태그의 depth 순서 갱신 (selected 태그가 더 앞으로 나오도록 함)
     if (type === "selected") {
       if (tag === this.selected) {
         const parent = this.searchByLocation(event);
-        parent.children.push(tag);
-        tag.parent = parent;
+        parent.push(tag);
       }
       this.elem.removeChild(tag.elem);
       this.elem.appendChild(tag.elem);
@@ -339,7 +337,7 @@ const board = {
         tag.setSize(width, height);
         tag.setPos(x, y);
       }, this.selected);
-      parent.children.push(this.selected);
+      parent.push(this.selected);
       this.restore();
     }
     this.forEach((tag) => tag.setState("located"));

--- a/js/renderTags.js
+++ b/js/renderTags.js
@@ -34,6 +34,7 @@ const tagClickHandler = (data) => {
       el.classList.remove("click-tag");
     });
     target.classList.toggle("click-tag");
+    if (board.selected) board.clearSelected();
     if (target.textContent === board.ready?.tagName) {
       board.clearReady();
     } else {
@@ -47,7 +48,6 @@ const renderTags = function (arr, cls) {
     wrapTag.innerHTML = "";
     const { redColor, greenColor, blueColor } = theme;
     const basic = [redColor, greenColor, blueColor];
-    const chosen = [[...basic]];
     const fragment = document.createDocumentFragment();
     arr.forEach((data,index) => {
       const { tagName, keyword } = data;

--- a/js/tag.js
+++ b/js/tag.js
@@ -22,8 +22,15 @@ class Tag {
 
   // DOM 요소의 글자 크기를 크기에 비례해서 지정
   setFontSize() {
-    const fontSize = (this.height ?? 100) / 4;
-    this.elem.style.fontSize = `${fontSize > 40 ? 40 : fontSize}px`;
+    const { size } = grid;
+    if (this.children.length) {
+      this.elem.classList.add("tag-text-loc");
+      this.elem.style.fontSize = `${size * 0.7}px`;
+    } else {
+      this.elem.classList.remove("tag-text-loc");
+      const fontSize = (this.height ?? 100) / 4;
+      this.elem.style.fontSize = `${fontSize > 40 ? 40 : fontSize}px`;
+    }
   }
 
   // DOM 요소의 width, height 스타일 및 글자 크기 설정
@@ -159,5 +166,16 @@ class Tag {
         }
       });
     }
+  }
+
+  push(tag) {
+    this.children.push(tag);
+    this.setFontSize();
+    tag.parent = this;
+  }
+
+  remove(tag) {
+    this.children.splice(this.children.indexOf(tag), 1);
+    this.setFontSize();
   }
 }

--- a/js/tag.js
+++ b/js/tag.js
@@ -178,4 +178,11 @@ class Tag {
     this.children.splice(this.children.indexOf(tag), 1);
     this.setFontSize();
   }
+
+  rearrangeChildren() {
+    this.children.sort((a, b) => {
+      if (a.y === b.y) return a.x - b.x;
+      return a.y - b.y;
+    });
+  }
 }


### PR DESCRIPTION
1. 자식 요소가 있는 태그는 태그 글자를 좌측 상단에 배치
2. selected 상태의 태그에 자식 요소를 삽입하면 자식 요소의 배치가 뒤로 가는 버그 수정
  (selected 상태일 때 태그 선택 바에서 태그를 선택하면 selected가 해제되도록 함)
3. 보드에 변동이 있고난 후에 반드시 모든 태그의 children 순서를 위치에 따라 정렬하도록 함
4. 태그 삭제 기능 추가